### PR TITLE
add __pycache__/ to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -302,3 +302,5 @@ TSWLatexianTemp*
 
 writing/abstract/example.pdf
 writing/abstract/example_figure.pdf
+
+__pycache__/


### PR DESCRIPTION
This PR adds __pycache__/ to the .gitignore to keep the working directory as clean as possible for new users.