### PR TITLE
revert version_regex to release_version

### DIFF
--- a/changelog-ci-config.json
+++ b/changelog-ci-config.json
@@ -6,7 +6,7 @@
     "include_unlabeled_changes": true,
     "unlabeled_group_title": "Unlabeled Changes",
     "pull_request_title_regex": "^Release",
-    "version_regex": "v0.0",
+    "version_regex": "release_version",
     "exclude_labels": ["bot", "dependabot", "ci"],
     "group_config": [
       {


### PR DESCRIPTION
This string is needed to connect the github event input variable.