### PR TITLE
Fuel transactions NaNs to 0s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Includes New Features, Enhancements, and Bug Fixes.
 ### Example
 Includes analysis notebooks.
 
-* Analysis scripts (#31, #37)
+* Analysis scripts (#31, #37, #56)
 * Recipe update analysis (#41, #37)
 * Baseline recycle scenario analysis (#20, #37)
 * Preference analysis (#6, #15, #37)

--- a/scripts/fuel_transactions.py
+++ b/scripts/fuel_transactions.py
@@ -11,8 +11,13 @@ def used_fuel_transactions(transactions, fuels):
         The types of fuel traded.
     """
     for fuel in fuels:
-        transactions[f'used_{fuel}_total'] = transactions.loc[
-            transactions['Commodity'] == f'used_{fuel}']['Quantity'].cumsum()
+        transactions[f'used_{fuel}'] = \
+            transactions.loc[
+                transactions['Commodity'] == f'used_{fuel}']['Quantity']
+        transactions[f'used_{fuel}_total'] = \
+            transactions[f'used_{fuel}'].fillna(0)
+        transactions[f'used_{fuel}_total'] = \
+            transactions[f'used_{fuel}_total'].cumsum()
 
     return transactions
 
@@ -29,8 +34,12 @@ def fresh_fuel_transactions(transactions, fuels):
         The types of fuel traded.
     """
     for fuel in fuels:
-        transactions[f'fresh_{fuel}_total'] = transactions.loc[
-            transactions['Commodity'] == f'fresh_{fuel}']['Quantity'].cumsum()
+        transactions[f'fresh_{fuel}'] = transactions.loc[
+            transactions['Commodity'] == f'fresh_{fuel}']['Quantity']
+        transactions[f'fresh_{fuel}_total'] = \
+            transactions[f'fresh_{fuel}'].fillna(0)
+        transactions[f'fresh_{fuel}_total'] = \
+            transactions[f'fresh_{fuel}_total'].cumsum()
 
     return transactions
 


### PR DESCRIPTION
This PR creates two new columns for fresh and used fuel, then sets the NaN values to 0s, and finally sums the values to create the total fresh and used columns.

This PR closes #43 

There's a plot in the issue, and, for the same scenario, the scripts now output:
![image](https://github.com/user-attachments/assets/0f762f3a-4f4d-4989-9441-a1c178dae340)
